### PR TITLE
Use Shouldly instead of Fluent Assertions

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,11 +1,11 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="FastMember" Version="1.5.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="MSTest" Version="4.0.2" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="ZString" Version="2.6.0" />
   </ItemGroup>
 </Project>

--- a/src/insights/QLimitive.UnitTests/QLimitive.UnitTests.csproj
+++ b/src/insights/QLimitive.UnitTests/QLimitive.UnitTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="MSTest" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
@@ -1,8 +1,8 @@
 ﻿using Cysharp.Text;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.Mappings;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -22,9 +22,9 @@ public sealed class ComplexQueryTest
 @"select count(*) as [Count] from [dbo].[T_People]
 where
     [Id] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -46,10 +46,10 @@ where
 @"select count(*) as [Count] from [dbo].[T_People]
 where
     [Id] = @p1 and [姓] <> @p2";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -71,10 +71,10 @@ where
 @"select count(*) as [Count] from [dbo].[T_People]
 where
     [Id] = @p1 or [姓] <> @p2";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -105,10 +105,10 @@ where
 from [dbo].[T_People]
 where
     [Id] = @p1 or [姓] <> @p2";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -142,11 +142,11 @@ where
 order by
     [Id],
     [Age] desc";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 20);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 20);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -183,12 +183,12 @@ where
 order by
     [Id],
     [Age] desc";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 20);
-        actual.Parameters.Should().Contain("term", "csharp");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 20);
+        actual.Parameters.ShouldContainKeyAndValue("term", "csharp");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -234,14 +234,11 @@ set
     [UpdatedAt] = SYSDATETIME()
 where
     [Id] = @p2 or [姓] <> @p3";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(
-        [
-            new("Age", null),
-            new("p2", 1),
-            new("p3", "xin9le"),
-        ]);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("Age", null);
+        actual.Parameters.ShouldContainKeyAndValue("p2", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p3", "xin9le");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -263,10 +260,10 @@ where
 @"delete from [dbo].[T_People]
 where
     [Id] = @p1 or [姓] <> @p2";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
         static Query createQuery(DbDialect dialect)
         {

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/CountTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/CountTest.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -17,7 +17,7 @@ public sealed class CountTest
     {
         var actual = QueryBuilder.Count<Person>(this.Dialect);
         var expect = "select count(*) as [Count] from [dbo].[T_People]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/DeleteTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/DeleteTest.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -17,7 +17,7 @@ public sealed class DeleteTest
     {
         var actual = QueryBuilder.Delete<Person>(this.Dialect);
         var expect = "delete from [dbo].[T_People]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/InsertTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/InsertTest.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -37,18 +37,15 @@ values
     @CreatedAt,
     @ModifiedAt
 )";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(
-        [
-            new("LastName", null),
-            new("FirstName", null),
-            new("Age", null),
-            new("Sex", null),
-            new("HasChildren", null),
-            new("CreatedAt", null),
-            new("ModifiedAt", null),
-        ]);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("LastName", null);
+        actual.Parameters.ShouldContainKeyAndValue("FirstName", null);
+        actual.Parameters.ShouldContainKeyAndValue("Age", null);
+        actual.Parameters.ShouldContainKeyAndValue("Sex", null);
+        actual.Parameters.ShouldContainKeyAndValue("HasChildren", null);
+        actual.Parameters.ShouldContainKeyAndValue("CreatedAt", null);
+        actual.Parameters.ShouldContainKeyAndValue("ModifiedAt", null);
     }
 
 
@@ -77,15 +74,12 @@ values
     SYSDATETIME(),
     SYSDATETIME()
 )";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(
-        [
-            new("LastName", null),
-            new("FirstName", null),
-            new("Age", null),
-            new("Sex", null),
-            new("HasChildren", null),
-        ]);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("LastName", null);
+        actual.Parameters.ShouldContainKeyAndValue("FirstName", null);
+        actual.Parameters.ShouldContainKeyAndValue("Age", null);
+        actual.Parameters.ShouldContainKeyAndValue("Sex", null);
+        actual.Parameters.ShouldContainKeyAndValue("HasChildren", null);
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/OrderByTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/OrderByTest.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -19,8 +19,8 @@ public sealed class OrderByTest
         var expect =
 @"order by
     [姓]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
 
         static Query createQuery(DbDialect dialect)
         {
@@ -40,8 +40,8 @@ public sealed class OrderByTest
         var expect =
 @"order by
     [Age] desc";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
 
         static Query createQuery(DbDialect dialect)
         {

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/SelectTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/SelectTest.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -27,8 +27,8 @@ public sealed class SelectTest
     [CreatedAt] as [CreatedAt],
     [UpdatedAt] as [ModifiedAt]
 from [dbo].[T_People]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
     }
 
 
@@ -40,8 +40,8 @@ from [dbo].[T_People]";
 @"select
     [姓] as [LastName]
 from [dbo].[T_People]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
     }
 
 
@@ -53,8 +53,8 @@ from [dbo].[T_People]";
 @"select
     [姓] as [LastName]
 from [dbo].[T_People]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
     }
 
 
@@ -67,8 +67,8 @@ from [dbo].[T_People]";
     [姓] as [LastName],
     [Age] as [Age]
 from [dbo].[T_People]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
     }
 
 
@@ -81,7 +81,7 @@ from [dbo].[T_People]";
     [姓] as [LastName],
     [Age] as [Age]
 from [dbo].[T_People]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/ThenByTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/ThenByTest.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -20,8 +20,8 @@ public sealed class ThenByTest
 @"order by
     [姓],
     [Age]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
 
         static Query createQuery(DbDialect dialect)
         {
@@ -43,8 +43,8 @@ public sealed class ThenByTest
 @"order by
     [Age] desc,
     [名] desc";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
 
         static Query createQuery(DbDialect dialect)
         {
@@ -68,8 +68,8 @@ public sealed class ThenByTest
     [Age] desc,
     [名],
     [CreatedAt] desc";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
 
         static Query createQuery(DbDialect dialect)
         {

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/TruncateTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/TruncateTest.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -17,7 +17,7 @@ public sealed class TruncateTest
     {
         var actual = QueryBuilder.Truncate<Person>(this.Dialect);
         var expect = "truncate table [dbo].[T_People]";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/UpdateTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/UpdateTest.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Generic;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -28,19 +27,16 @@ set
     [HasChildren] = @HasChildren,
     [CreatedAt] = @CreatedAt,
     [UpdatedAt] = @ModifiedAt";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(
-        [
-            new("Id", null),
-            new("LastName", null),
-            new("FirstName", null),
-            new("Age", null),
-            new("Sex", null),
-            new("HasChildren", null),
-            new("CreatedAt", null),
-            new("ModifiedAt", null),
-        ]);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("Id", null);
+        actual.Parameters.ShouldContainKeyAndValue("LastName", null);
+        actual.Parameters.ShouldContainKeyAndValue("FirstName", null);
+        actual.Parameters.ShouldContainKeyAndValue("Age", null);
+        actual.Parameters.ShouldContainKeyAndValue("Sex", null);
+        actual.Parameters.ShouldContainKeyAndValue("HasChildren", null);
+        actual.Parameters.ShouldContainKeyAndValue("CreatedAt", null);
+        actual.Parameters.ShouldContainKeyAndValue("ModifiedAt", null);
     }
 
 
@@ -59,17 +55,14 @@ set
     [HasChildren] = @HasChildren,
     [CreatedAt] = SYSDATETIME(),
     [UpdatedAt] = SYSDATETIME()";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(
-        [
-            new("Id", null),
-            new("LastName", null),
-            new("FirstName", null),
-            new("Age", null),
-            new("Sex", null),
-            new("HasChildren", null),
-        ]);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("Id", null);
+        actual.Parameters.ShouldContainKeyAndValue("LastName", null);
+        actual.Parameters.ShouldContainKeyAndValue("FirstName", null);
+        actual.Parameters.ShouldContainKeyAndValue("Age", null);
+        actual.Parameters.ShouldContainKeyAndValue("Sex", null);
+        actual.Parameters.ShouldContainKeyAndValue("HasChildren", null);
     }
 
 
@@ -81,9 +74,9 @@ set
 @"update [dbo].[T_People]
 set
     [姓] = @LastName";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(new KeyValuePair<string, object?>("LastName", null));
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("LastName", null);
     }
 
 
@@ -95,9 +88,9 @@ set
 @"update [dbo].[T_People]
 set
     [姓] = @LastName";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(new KeyValuePair<string, object?>("LastName", null));
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("LastName", null);
     }
 
 
@@ -110,13 +103,10 @@ set
 set
     [姓] = @LastName,
     [UpdatedAt] = @ModifiedAt";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(
-        [
-            new("LastName", null),
-            new("ModifiedAt", null),
-        ]);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("LastName", null);
+        actual.Parameters.ShouldContainKeyAndValue("ModifiedAt", null);
     }
 
 
@@ -129,8 +119,8 @@ set
 set
     [姓] = @LastName,
     [UpdatedAt] = SYSDATETIME()";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain(new KeyValuePair<string, object?>("LastName", null));
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("LastName", null);
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/WhereTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/WhereTest.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.UnitTests.SqlServer.Models;
+using Shouldly;
 
 namespace QLimitive.UnitTests.SqlServer.Cases;
 
@@ -23,9 +23,9 @@ public sealed class WhereTest
 @"where
     [Id] = @p1";
 
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -46,9 +46,9 @@ public sealed class WhereTest
 @"where
     [Id] <> @p1";
 
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -69,9 +69,9 @@ public sealed class WhereTest
 @"where
     [Id] > @p1";
 
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -92,9 +92,9 @@ public sealed class WhereTest
 @"where
     [Id] < @p1";
 
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
   
         static Query createQuery(DbDialect dialect)
         {
@@ -114,9 +114,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] >= @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -136,9 +136,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] <= @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -158,8 +158,8 @@ public sealed class WhereTest
         var expect =
 @"where
     [姓] is null";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
 
         static Query createQuery(DbDialect dialect)
         {
@@ -179,8 +179,8 @@ public sealed class WhereTest
         var expect =
 @"where
     [姓] is not null";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
 
         static Query createQuery(DbDialect dialect)
         {
@@ -200,10 +200,10 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] > @p1 and [姓] = @p2";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -223,10 +223,10 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] > @p1 or [姓] = @p2";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -246,11 +246,11 @@ public sealed class WhereTest
         var expect =
 @"where
     ([Id] > @p1 and [姓] = @p2) or [Age] <= @p3";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 30);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -270,11 +270,11 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] > @p1 and ([姓] = @p2 or [Age] <= @p3)";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 30);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -294,11 +294,11 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] > @p1 or ([姓] = @p2 and [Age] <= @p3)";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 30);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -318,11 +318,11 @@ public sealed class WhereTest
         var expect =
 @"where
     ([Id] > @p1 or [姓] = @p2) and [Age] <= @p3";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 30);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -344,15 +344,15 @@ public sealed class WhereTest
         var expect =
 @"where
     ([Id] > @p1 or [姓] = @p2) and [Age] <= @p3 and ([Id] in @p4 or [Id] in @p5)";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 30);
-        actual.Parameters.Should().ContainKey("p4");
-        actual.Parameters!["p4"].Should().BeEquivalentTo(value1);
-        actual.Parameters.Should().ContainKey("p5");
-        actual.Parameters!["p5"].Should().BeEquivalentTo(value2);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 30);
+        actual.Parameters.ShouldContainKey("p4");
+        actual.Parameters!["p4"].ShouldBeEquivalentTo(value1);
+        actual.Parameters.ShouldContainKey("p5");
+        actual.Parameters!["p5"].ShouldBeEquivalentTo(value2);
 
         static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
         {
@@ -375,15 +375,15 @@ public sealed class WhereTest
         var expect =
 @"where
     (([Id] > @p1 or [姓] = @p2) and [Age] <= @p3) or ([Id] in @p4 or [Id] in @p5)";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 30);
-        actual.Parameters.Should().ContainKey("p4");
-        actual.Parameters!["p4"].Should().BeEquivalentTo(value1);
-        actual.Parameters.Should().ContainKey("p5");
-        actual.Parameters!["p5"].Should().BeEquivalentTo(value2);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 30);
+        actual.Parameters.ShouldContainKey("p4");
+        actual.Parameters!["p4"].ShouldBeEquivalentTo(value1);
+        actual.Parameters.ShouldContainKey("p5");
+        actual.Parameters!["p5"].ShouldBeEquivalentTo(value2);
 
         static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
         {
@@ -404,11 +404,11 @@ public sealed class WhereTest
         var expect =
 @"where
     (([Id] > @p1 or [姓] = @p2) and [Age] <= @p3) or 1 = 0";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 30);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -429,11 +429,11 @@ public sealed class WhereTest
         var expect =
 @"where
     ([Id] > @p1 or [姓] = @p2) and ([Age] <= @p3 or 1 = 0)";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", 1);
-        actual.Parameters.Should().Contain("p2", "xin9le");
-        actual.Parameters.Should().Contain("p3", 30);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", 1);
+        actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
+        actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -455,10 +455,10 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] in @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().ContainKey("p1");
-        actual.Parameters!["p1"].Should().BeEquivalentTo(values);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKey("p1");
+        actual.Parameters!["p1"].ShouldBeEquivalentTo(values);
 
         static Query createQuery(DbDialect dialect, int[] values)
         {
@@ -480,12 +480,12 @@ public sealed class WhereTest
         var expect =
 @"where
     ([Id] in @p1 or [Id] in @p2)";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().ContainKey("p1");
-        actual.Parameters!["p1"].Should().BeEquivalentTo(value1);
-        actual.Parameters.Should().ContainKey("p2");
-        actual.Parameters!["p2"].Should().BeEquivalentTo(value2);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKey("p1");
+        actual.Parameters!["p1"].ShouldBeEquivalentTo(value1);
+        actual.Parameters.ShouldContainKey("p2");
+        actual.Parameters!["p2"].ShouldBeEquivalentTo(value2);
 
         static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
         {
@@ -506,8 +506,8 @@ public sealed class WhereTest
         var expect =
 @"where
     1 = 0";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().BeNull();
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldBeNull();
 
         static Query createQuery(DbDialect dialect)
         {
@@ -530,12 +530,12 @@ public sealed class WhereTest
         var expect =
 @"where
     ([Id] in @p1 or [Id] in @p2)";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().ContainKey("p1");
-        actual.Parameters!["p1"].Should().BeEquivalentTo(value1);
-        actual.Parameters.Should().ContainKey("p2");
-        actual.Parameters!["p2"].Should().BeEquivalentTo(value2);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKey("p1");
+        actual.Parameters!["p1"].ShouldBeEquivalentTo(value1);
+        actual.Parameters.ShouldContainKey("p2");
+        actual.Parameters!["p2"].ShouldBeEquivalentTo(value2);
 
         static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
         {
@@ -557,9 +557,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", id);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", id);
 
         static Query createQuery(DbDialect dialect, int id)
         {
@@ -579,9 +579,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [姓] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", "aaa");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", "aaa");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -609,9 +609,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [姓] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", some.InstanceMethod());
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", some.InstanceMethod());
 
         static Query createQuery(DbDialect dialect, AccessorProvider some)
         {
@@ -631,9 +631,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [姓] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", "123");
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", "123");
 
         static Query createQuery(DbDialect dialect)
         {
@@ -655,9 +655,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [Age] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", some.InstanceProperty);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", some.InstanceProperty);
 
         static Query createQuery(DbDialect dialect, AccessorProvider some)
         {
@@ -678,9 +678,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [Id] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", ids[0]);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", ids[0]);
 
         static Query createQuery(DbDialect dialect, int[] ids)
         {
@@ -700,9 +700,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [姓] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", AccessorProvider.StaticMethod());
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", AccessorProvider.StaticMethod());
 
         static Query createQuery(DbDialect dialect)
         {
@@ -722,9 +722,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [Age] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", AccessorProvider.StaticProperty);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", AccessorProvider.StaticProperty);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -744,9 +744,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [Sex] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", Sex.Male);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", Sex.Male);
 
         static Query createQuery(DbDialect dialect)
         {
@@ -767,9 +767,9 @@ public sealed class WhereTest
         var expect =
 @"where
     [Sex] = @p1";
-        actual.Text.Should().Be(expect);
-        actual.Parameters.Should().NotBeNull();
-        actual.Parameters.Should().Contain("p1", (byte)Sex.Female);
+        actual.Text.ShouldBe(expect);
+        actual.Parameters.ShouldNotBeNull();
+        actual.Parameters.ShouldContainKeyAndValue("p1", (byte)Sex.Female);
 
         static Query createQuery(DbDialect dialect)
         {

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/WhereTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/WhereTest.cs
@@ -350,9 +350,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
         actual.Parameters.ShouldContainKey("p4");
-        actual.Parameters!["p4"].ShouldBeEquivalentTo(value1);
+        actual.Parameters!["p4"].ShouldBe(value1);
         actual.Parameters.ShouldContainKey("p5");
-        actual.Parameters!["p5"].ShouldBeEquivalentTo(value2);
+        actual.Parameters!["p5"].ShouldBe(value2);
 
         static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
         {
@@ -381,9 +381,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
         actual.Parameters.ShouldContainKey("p4");
-        actual.Parameters!["p4"].ShouldBeEquivalentTo(value1);
+        actual.Parameters!["p4"].ShouldBe(value1);
         actual.Parameters.ShouldContainKey("p5");
-        actual.Parameters!["p5"].ShouldBeEquivalentTo(value2);
+        actual.Parameters!["p5"].ShouldBe(value2);
 
         static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
         {
@@ -458,7 +458,7 @@ public sealed class WhereTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKey("p1");
-        actual.Parameters!["p1"].ShouldBeEquivalentTo(values);
+        actual.Parameters!["p1"].ShouldBe(values);
 
         static Query createQuery(DbDialect dialect, int[] values)
         {
@@ -483,9 +483,9 @@ public sealed class WhereTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKey("p1");
-        actual.Parameters!["p1"].ShouldBeEquivalentTo(value1);
+        actual.Parameters!["p1"].ShouldBe(value1);
         actual.Parameters.ShouldContainKey("p2");
-        actual.Parameters!["p2"].ShouldBeEquivalentTo(value2);
+        actual.Parameters!["p2"].ShouldBe(value2);
 
         static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
         {
@@ -533,9 +533,9 @@ public sealed class WhereTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKey("p1");
-        actual.Parameters!["p1"].ShouldBeEquivalentTo(value1);
+        actual.Parameters!["p1"].ShouldBe(value1);
         actual.Parameters.ShouldContainKey("p2");
-        actual.Parameters!["p2"].ShouldBeEquivalentTo(value2);
+        actual.Parameters!["p2"].ShouldBe(value2);
 
         static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
         {
@@ -769,7 +769,7 @@ public sealed class WhereTest
     [Sex] = @p1";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldNotBeNull();
-        actual.Parameters.ShouldContainKeyAndValue("p1", (byte)Sex.Female);
+        actual.Parameters.ShouldContainKeyAndValue("p1", (int)Sex.Female);
 
         static Query createQuery(DbDialect dialect)
         {


### PR DESCRIPTION
This pull request migrates the unit tests in the `QLimitive.UnitTests` project from using the `FluentAssertions` assertion library to `Shouldly`. All assertion usages in the test cases have been updated accordingly, and the relevant package references have been changed. This streamlines the assertion style across the codebase and removes the dependency on `FluentAssertions`.