### PR TITLE
Chores refactoring

### DIFF
--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
@@ -27,6 +27,7 @@ where
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -36,6 +37,7 @@ where
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -52,6 +54,7 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -61,6 +64,7 @@ where
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -77,6 +81,7 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -86,6 +91,7 @@ where
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -111,6 +117,7 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -120,6 +127,7 @@ where
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -149,6 +157,7 @@ order by
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 20);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -160,6 +169,7 @@ order by
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -191,6 +201,7 @@ order by
         actual.Parameters.ShouldContainKeyAndValue("p3", 20);
         actual.Parameters.ShouldContainKeyAndValue("term", "csharp");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -221,6 +232,7 @@ order by
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -241,6 +253,7 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p2", 1);
         actual.Parameters.ShouldContainKeyAndValue("p3", "xin9le");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -250,6 +263,7 @@ where
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -266,6 +280,7 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -275,5 +290,6 @@ where
                 return builder.Build();
             }
         }
+        #endregion
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
@@ -10,13 +10,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class ComplexQueryTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void CountWhere1()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"select count(*) as [Count] from [dbo].[T_People]
 where
@@ -25,9 +27,9 @@ where
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Count();
                 builder.Where(static x => x.Id == 1);
@@ -40,7 +42,7 @@ where
     [TestMethod]
     public void CountWhere2()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"select count(*) as [Count] from [dbo].[T_People]
 where
@@ -50,9 +52,9 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Count();
                 builder.Where(static x => x.Id == 1 && x.LastName != "xin9le");
@@ -65,7 +67,7 @@ where
     [TestMethod]
     public void CountWhere3()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"select count(*) as [Count] from [dbo].[T_People]
 where
@@ -75,9 +77,9 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Count();
                 builder.Where(static x => x.Id == 1 || x.LastName != "xin9le");
@@ -90,7 +92,7 @@ where
     [TestMethod]
     public void SelectWhere()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"select
     [Id] as [Id],
@@ -109,9 +111,9 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Select();
                 builder.Where(static x => x.Id == 1 || x.LastName != "xin9le");
@@ -124,7 +126,7 @@ where
     [TestMethod]
     public void SelectWhereOrderByThenBy()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"select
     [Id] as [Id],
@@ -147,9 +149,9 @@ order by
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 20);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Select();
                 builder.Where(static x => x.Id == 1 || x.LastName != "xin9le" && x.Age > 20);
@@ -164,7 +166,7 @@ order by
     [TestMethod]
     public void SelectWhereAsIsOrderByThenBy()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"select
     [Id] as [Id],
@@ -189,9 +191,9 @@ order by
         actual.Parameters.ShouldContainKeyAndValue("p3", 20);
         actual.Parameters.ShouldContainKeyAndValue("term", "csharp");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Select();
                 builder.Where(static x => x.Id == 1 || x.LastName != "xin9le" && x.Age > 20);
@@ -213,7 +215,7 @@ order by
 
                     bindParameters ??= [];
                     bindParameters.Add(nameof(term), term);
-                }, dialect);
+                }, s_dialect);
                 builder.OrderBy(static x => x.Id);
                 builder.ThenByDescending(static x => x.Age);
                 return builder.Build();
@@ -225,7 +227,7 @@ order by
     [TestMethod]
     public void UpdateWhere()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"update [dbo].[T_People]
 set
@@ -239,9 +241,9 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p2", 1);
         actual.Parameters.ShouldContainKeyAndValue("p3", "xin9le");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Update(static x => new { x.Age, x.ModifiedAt }, useAmbientValue: true);
                 builder.Where(static x => x.Id == 1 || x.LastName != "xin9le");
@@ -254,7 +256,7 @@ where
     [TestMethod]
     public void DeleteWhere()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"delete from [dbo].[T_People]
 where
@@ -264,9 +266,9 @@ where
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Delete();
                 builder.Where(static x => x.Id == 1 || x.LastName != "xin9le");

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
@@ -1,5 +1,4 @@
-﻿using Cysharp.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using QLimitive.Mappings;
 using QLimitive.UnitTests.SqlServer.Models;
 using Shouldly;
@@ -196,7 +195,7 @@ order by
             {
                 builder.Select();
                 builder.Where(static x => x.Id == 1 || x.LastName != "xin9le" && x.Age > 20);
-                builder.AsIs(static (ref Utf16ValueStringBuilder stringBuilder, ref BindParameterCollection? bindParameters, DbDialect dialect) =>
+                builder.AsIs(static (ref stringBuilder, ref bindParameters, dialect) =>
                 {
                     var term = "csharp";
                     var table = TableMappingInfo.Get<Person>();

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/CountTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/CountTest.cs
@@ -9,13 +9,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class CountTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void All()
     {
-        var actual = QueryBuilder.Count<Person>(this.Dialect);
+        var actual = QueryBuilder.Count<Person>(s_dialect);
         var expect = "select count(*) as [Count] from [dbo].[T_People]";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/DeleteTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/DeleteTest.cs
@@ -9,13 +9,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class DeleteTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void All()
     {
-        var actual = QueryBuilder.Delete<Person>(this.Dialect);
+        var actual = QueryBuilder.Delete<Person>(s_dialect);
         var expect = "delete from [dbo].[T_People]";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/InsertTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/InsertTest.cs
@@ -9,13 +9,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class InsertTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void ReferencePropertyValue()
     {
-        var actual = QueryBuilder.Insert<Person>(this.Dialect, useAmbientValue: false);
+        var actual = QueryBuilder.Insert<Person>(s_dialect, useAmbientValue: false);
         var expect =
 @"insert into [dbo].[T_People]
 (
@@ -52,7 +54,7 @@ values
     [TestMethod]
     public void ReferenceAmbientValue()
     {
-        var actual = QueryBuilder.Insert<Person>(this.Dialect, useAmbientValue: true);
+        var actual = QueryBuilder.Insert<Person>(s_dialect, useAmbientValue: true);
         var expect =
 @"insert into [dbo].[T_People]
 (

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/OrderByTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/OrderByTest.cs
@@ -9,22 +9,24 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class OrderByTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void Ascending()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"order by
     [姓]";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.OrderBy(static x => x.LastName);
                 return builder.Build();
@@ -36,16 +38,16 @@ public sealed class OrderByTest
     [TestMethod]
     public void Descending()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"order by
     [Age] desc";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.OrderByDescending(static x => x.Age);
                 return builder.Build();

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/OrderByTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/OrderByTest.cs
@@ -24,6 +24,7 @@ public sealed class OrderByTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -32,6 +33,7 @@ public sealed class OrderByTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -45,6 +47,7 @@ public sealed class OrderByTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -53,5 +56,6 @@ public sealed class OrderByTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/SelectTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/SelectTest.cs
@@ -9,13 +9,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class SelectTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void AllColumns()
     {
-        var actual = QueryBuilder.Select<Person>(this.Dialect);
+        var actual = QueryBuilder.Select<Person>(s_dialect);
         var expect =
 @"select
     [Id] as [Id],
@@ -35,7 +37,7 @@ from [dbo].[T_People]";
     [TestMethod]
     public void OneColumn()
     {
-        var actual = QueryBuilder.Select<Person>(this.Dialect, static x => x.LastName);
+        var actual = QueryBuilder.Select<Person>(s_dialect, static x => x.LastName);
         var expect =
 @"select
     [姓] as [LastName]
@@ -48,7 +50,7 @@ from [dbo].[T_People]";
     [TestMethod]
     public void OneColumn_AnonymousType()
     {
-        var actual = QueryBuilder.Select<Person>(this.Dialect, static x => new { x.LastName });
+        var actual = QueryBuilder.Select<Person>(s_dialect, static x => new { x.LastName });
         var expect =
 @"select
     [姓] as [LastName]
@@ -61,7 +63,7 @@ from [dbo].[T_People]";
     [TestMethod]
     public void TwoColumns()
     {
-        var actual = QueryBuilder.Select<Person>(this.Dialect, static x => new { x.LastName, x.Age });
+        var actual = QueryBuilder.Select<Person>(s_dialect, static x => new { x.LastName, x.Age });
         var expect =
 @"select
     [姓] as [LastName],
@@ -75,7 +77,7 @@ from [dbo].[T_People]";
     [TestMethod]
     public void MultiColumns_IncludeNotMapped()
     {
-        var actual = QueryBuilder.Select<Person>(this.Dialect, static x => new { x.LastName, x.FullName, x.Age });
+        var actual = QueryBuilder.Select<Person>(s_dialect, static x => new { x.LastName, x.FullName, x.Age });
         var expect =
 @"select
     [姓] as [LastName],

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/ThenByTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/ThenByTest.cs
@@ -25,6 +25,7 @@ public sealed class ThenByTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -34,6 +35,7 @@ public sealed class ThenByTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -48,6 +50,7 @@ public sealed class ThenByTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -57,6 +60,7 @@ public sealed class ThenByTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -73,6 +77,7 @@ public sealed class ThenByTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -84,5 +89,6 @@ public sealed class ThenByTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 }

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/ThenByTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/ThenByTest.cs
@@ -9,13 +9,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class ThenByTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void Ascending()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"order by
     [姓],
@@ -23,9 +25,9 @@ public sealed class ThenByTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.OrderBy(static x => x.LastName);
                 builder.ThenBy(static x => x.Age);
@@ -38,7 +40,7 @@ public sealed class ThenByTest
     [TestMethod]
     public void Descending()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"order by
     [Age] desc,
@@ -46,9 +48,9 @@ public sealed class ThenByTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.OrderByDescending(static x => x.Age);
                 builder.ThenByDescending(static x => x.FirstName);
@@ -61,7 +63,7 @@ public sealed class ThenByTest
     [TestMethod]
     public void Complex()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"order by
     [姓],
@@ -71,9 +73,9 @@ public sealed class ThenByTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.OrderBy(static x => x.LastName);
                 builder.ThenByDescending(static x => x.Age);

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/TruncateTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/TruncateTest.cs
@@ -9,13 +9,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class TruncateTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void Create()
     {
-        var actual = QueryBuilder.Truncate<Person>(this.Dialect);
+        var actual = QueryBuilder.Truncate<Person>(s_dialect);
         var expect = "truncate table [dbo].[T_People]";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/UpdateTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/UpdateTest.cs
@@ -9,13 +9,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class UpdateTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void AllColumns()
     {
-        var actual = QueryBuilder.Update<Person>(this.Dialect);
+        var actual = QueryBuilder.Update<Person>(s_dialect);
         var expect =
 @"update [dbo].[T_People]
 set
@@ -43,7 +45,7 @@ set
     [TestMethod]
     public void AllColumns_UseAmbientValue()
     {
-        var actual = QueryBuilder.Update<Person>(this.Dialect, useAmbientValue: true);
+        var actual = QueryBuilder.Update<Person>(s_dialect, useAmbientValue: true);
         var expect =
 @"update [dbo].[T_People]
 set
@@ -69,7 +71,7 @@ set
     [TestMethod]
     public void OneColumn()
     {
-        var actual = QueryBuilder.Update<Person>(this.Dialect, static x => x.LastName);
+        var actual = QueryBuilder.Update<Person>(s_dialect, static x => x.LastName);
         var expect =
 @"update [dbo].[T_People]
 set
@@ -83,7 +85,7 @@ set
     [TestMethod]
     public void OneColumn_AnonymousType()
     {
-        var actual = QueryBuilder.Update<Person>(this.Dialect, static x => new { x.LastName });
+        var actual = QueryBuilder.Update<Person>(s_dialect, static x => new { x.LastName });
         var expect =
 @"update [dbo].[T_People]
 set
@@ -97,7 +99,7 @@ set
     [TestMethod]
     public void MultiColumns()
     {
-        var actual = QueryBuilder.Update<Person>(this.Dialect, static x => new { x.LastName, x.FullName, x.ModifiedAt });
+        var actual = QueryBuilder.Update<Person>(s_dialect, static x => new { x.LastName, x.FullName, x.ModifiedAt });
         var expect =
 @"update [dbo].[T_People]
 set
@@ -113,7 +115,7 @@ set
     [TestMethod]
     public void MultiColumns_UseAmbientValue()
     {
-        var actual = QueryBuilder.Update<Person>(this.Dialect, static x => new { x.LastName, x.FullName, x.ModifiedAt }, useAmbientValue: true);
+        var actual = QueryBuilder.Update<Person>(s_dialect, static x => new { x.LastName, x.FullName, x.ModifiedAt }, useAmbientValue: true);
         var expect =
 @"update [dbo].[T_People]
 set

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/WhereTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/WhereTest.cs
@@ -12,13 +12,15 @@ namespace QLimitive.UnitTests.SqlServer.Cases;
 [TestClass]
 public sealed class WhereTest
 {
-    private DbDialect Dialect { get; } = DbDialect.SqlServer;
+    #region Fields
+    private static readonly DbDialect s_dialect = DbDialect.SqlServer;
+    #endregion
 
 
     [TestMethod]
     public void Equal()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] = @p1";
@@ -27,9 +29,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id == 1);
                 return builder.Build();
@@ -41,7 +43,7 @@ public sealed class WhereTest
     [TestMethod]
     public void NotEqual()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] <> @p1";
@@ -50,9 +52,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id != 1);
                 return builder.Build();
@@ -64,7 +66,7 @@ public sealed class WhereTest
     [TestMethod]
     public void GreaterThan()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] > @p1";
@@ -73,9 +75,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id > 1);
                 return builder.Build();
@@ -87,7 +89,7 @@ public sealed class WhereTest
     [TestMethod]
     public void LessThan()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] < @p1";
@@ -96,9 +98,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
   
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id < 1);
                 return builder.Build();
@@ -110,7 +112,7 @@ public sealed class WhereTest
     [TestMethod]
     public void GreaterThanOrEqual()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] >= @p1";
@@ -118,9 +120,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id >= 1);
                 return builder.Build();
@@ -132,7 +134,7 @@ public sealed class WhereTest
     [TestMethod]
     public void LessThanOrEqual()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] <= @p1";
@@ -140,9 +142,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id <= 1);
                 return builder.Build();
@@ -154,16 +156,16 @@ public sealed class WhereTest
     [TestMethod]
     public void Null()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [姓] is null";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.LastName == null);
                 return builder.Build();
@@ -175,16 +177,16 @@ public sealed class WhereTest
     [TestMethod]
     public void NotNull()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [姓] is not null";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.LastName != null);
                 return builder.Build();
@@ -196,7 +198,7 @@ public sealed class WhereTest
     [TestMethod]
     public void And()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] > @p1 and [姓] = @p2";
@@ -205,9 +207,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id > 1 && x.LastName == "xin9le");
                 return builder.Build();
@@ -219,7 +221,7 @@ public sealed class WhereTest
     [TestMethod]
     public void Or()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] > @p1 or [姓] = @p2";
@@ -228,9 +230,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id > 1 || x.LastName == "xin9le");
                 return builder.Build();
@@ -242,7 +244,7 @@ public sealed class WhereTest
     [TestMethod]
     public void AndOr1()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     ([Id] > @p1 and [姓] = @p2) or [Age] <= @p3";
@@ -252,9 +254,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id > 1 && x.LastName == "xin9le" || x.Age <= 30);
                 return builder.Build();
@@ -266,7 +268,7 @@ public sealed class WhereTest
     [TestMethod]
     public void AndOr2()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] > @p1 and ([姓] = @p2 or [Age] <= @p3)";
@@ -276,9 +278,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id > 1 && (x.LastName == "xin9le" || x.Age <= 30));
                 return builder.Build();
@@ -290,7 +292,7 @@ public sealed class WhereTest
     [TestMethod]
     public void AndOr3()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Id] > @p1 or ([姓] = @p2 and [Age] <= @p3)";
@@ -300,9 +302,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Id > 1 || x.LastName == "xin9le" && x.Age <= 30);
                 return builder.Build();
@@ -314,7 +316,7 @@ public sealed class WhereTest
     [TestMethod]
     public void AndOr4()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     ([Id] > @p1 or [姓] = @p2) and [Age] <= @p3";
@@ -324,9 +326,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => (x.Id > 1 || x.LastName == "xin9le") && x.Age <= 30);
                 return builder.Build();
@@ -340,7 +342,7 @@ public sealed class WhereTest
     {
         var value1 = Enumerable.Range(0, 1000).ToArray();
         var value2 = Enumerable.Range(1000, 234).ToArray();
-        var actual = createQuery(this.Dialect, value1, value2);
+        var actual = createQuery(value1, value2);
         var expect =
 @"where
     ([Id] > @p1 or [姓] = @p2) and [Age] <= @p3 and ([Id] in @p4 or [Id] in @p5)";
@@ -354,9 +356,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p5");
         actual.Parameters!["p5"].ShouldBe(value2);
 
-        static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
+        static Query createQuery(int[] value1, int[] value2)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 var values = value1.Concat(value2);
                 builder.Where(x => (x.Id > 1 || x.LastName == "xin9le") && x.Age <= 30 && values.Contains(x.Id));
@@ -371,7 +373,7 @@ public sealed class WhereTest
     {
         var value1 = Enumerable.Range(0, 1000).ToArray();
         var value2 = Enumerable.Range(1000, 234).ToArray();
-        var actual = createQuery(this.Dialect, value1, value2);
+        var actual = createQuery(value1, value2);
         var expect =
 @"where
     (([Id] > @p1 or [姓] = @p2) and [Age] <= @p3) or ([Id] in @p4 or [Id] in @p5)";
@@ -385,9 +387,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p5");
         actual.Parameters!["p5"].ShouldBe(value2);
 
-        static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
+        static Query createQuery(int[] value1, int[] value2)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 var values = value1.Concat(value2);
                 builder.Where(x => (x.Id > 1 || x.LastName == "xin9le") && x.Age <= 30 || values.Contains(x.Id));
@@ -400,7 +402,7 @@ public sealed class WhereTest
     [TestMethod]
     public void AndOr7()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     (([Id] > @p1 or [姓] = @p2) and [Age] <= @p3) or 1 = 0";
@@ -410,9 +412,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 var values = System.Array.Empty<int>();
                 builder.Where(x => (x.Id > 1 || x.LastName == "xin9le") && x.Age <= 30 || values.Contains(x.Id));
@@ -425,7 +427,7 @@ public sealed class WhereTest
     [TestMethod]
     public void AndOr8()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     ([Id] > @p1 or [姓] = @p2) and ([Age] <= @p3 or 1 = 0)";
@@ -435,9 +437,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 var values = System.Array.Empty<int>();
                 builder.Where(x => (x.Id > 1 || x.LastName == "xin9le") && (x.Age <= 30 || values.Contains(x.Id)));
@@ -451,7 +453,7 @@ public sealed class WhereTest
     public void Contains_IEnumerable()
     {
         var values = Enumerable.Range(0, 3).ToArray();
-        var actual = createQuery(this.Dialect, values);
+        var actual = createQuery(values);
         var expect =
 @"where
     [Id] in @p1";
@@ -460,9 +462,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p1");
         actual.Parameters!["p1"].ShouldBe(values);
 
-        static Query createQuery(DbDialect dialect, int[] values)
+        static Query createQuery(int[] values)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(x => values.Contains(x.Id));
                 return builder.Build();
@@ -476,7 +478,7 @@ public sealed class WhereTest
     {
         var value1 = Enumerable.Range(0, 1000).ToArray();
         var value2 = Enumerable.Range(1000, 234).ToArray();
-        var actual = createQuery(this.Dialect, value1, value2);
+        var actual = createQuery(value1, value2);
         var expect =
 @"where
     ([Id] in @p1 or [Id] in @p2)";
@@ -487,9 +489,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p2");
         actual.Parameters!["p2"].ShouldBe(value2);
 
-        static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
+        static Query createQuery(int[] value1, int[] value2)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 var values = value1.Concat(value2);
                 builder.Where(x => values.Contains(x.Id));
@@ -502,16 +504,16 @@ public sealed class WhereTest
     [TestMethod]
     public void Contains_IEnumerable_NoElements()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     1 = 0";
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 var values = System.Array.Empty<int>();
                 builder.Where(x => values.Contains(x.Id));
@@ -526,7 +528,7 @@ public sealed class WhereTest
     {
         var value1 = Enumerable.Range(0, 1000).ToArray();
         var value2 = Enumerable.Range(1000, 234).ToArray();
-        var actual = createQuery(this.Dialect, value1, value2);
+        var actual = createQuery(value1, value2);
         var expect =
 @"where
     ([Id] in @p1 or [Id] in @p2)";
@@ -537,9 +539,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p2");
         actual.Parameters!["p2"].ShouldBe(value2);
 
-        static Query createQuery(DbDialect dialect, int[] value1, int[] value2)
+        static Query createQuery(int[] value1, int[] value2)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 var values = value1.Concat(value2).ToHashSet();
                 builder.Where(x => values.Contains(x.Id));
@@ -553,7 +555,7 @@ public sealed class WhereTest
     public void Variable()
     {
         var id = 1;
-        var actual = createQuery(this.Dialect, id);
+        var actual = createQuery(id);
         var expect =
 @"where
     [Id] = @p1";
@@ -561,9 +563,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", id);
 
-        static Query createQuery(DbDialect dialect, int id)
+        static Query createQuery(int id)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(x => x.Id == id);
                 return builder.Build();
@@ -575,7 +577,7 @@ public sealed class WhereTest
     [TestMethod]
     public void Constructor()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [姓] = @p1";
@@ -583,9 +585,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", "aaa");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.LastName == new string('a', 3));
                 return builder.Build();
@@ -605,7 +607,7 @@ public sealed class WhereTest
     public void InstanceMethod()
     {
         var some = new AccessorProvider();
-        var actual = createQuery(this.Dialect, some);
+        var actual = createQuery(some);
         var expect =
 @"where
     [姓] = @p1";
@@ -613,9 +615,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", some.InstanceMethod());
 
-        static Query createQuery(DbDialect dialect, AccessorProvider some)
+        static Query createQuery(AccessorProvider some)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(x => x.LastName == some.InstanceMethod());
                 return builder.Build();
@@ -627,7 +629,7 @@ public sealed class WhereTest
     [TestMethod]
     public void Lambda()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [姓] = @p1";
@@ -635,9 +637,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", "123");
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 Func<int, string> getName = static x => x.ToString(CultureInfo.InvariantCulture);
                 builder.Where(x => x.LastName == getName(123));
@@ -651,7 +653,7 @@ public sealed class WhereTest
     public void InstanceProperty()
     {
         var some = new AccessorProvider();
-        var actual = createQuery(this.Dialect, some);
+        var actual = createQuery(some);
         var expect =
 @"where
     [Age] = @p1";
@@ -659,9 +661,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", some.InstanceProperty);
 
-        static Query createQuery(DbDialect dialect, AccessorProvider some)
+        static Query createQuery(AccessorProvider some)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(x => x.Age == some.InstanceProperty);
                 return builder.Build();
@@ -674,7 +676,7 @@ public sealed class WhereTest
     public void Indexer()
     {
         var ids = new[] { 1, 2, 3 };
-        var actual = createQuery(this.Dialect, ids);
+        var actual = createQuery(ids);
         var expect =
 @"where
     [Id] = @p1";
@@ -682,9 +684,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", ids[0]);
 
-        static Query createQuery(DbDialect dialect, int[] ids)
+        static Query createQuery(int[] ids)
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(x => x.Id == ids[0]);
                 return builder.Build();
@@ -696,7 +698,7 @@ public sealed class WhereTest
     [TestMethod]
     public void StaticMethod()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [姓] = @p1";
@@ -704,9 +706,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", AccessorProvider.StaticMethod());
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.LastName == AccessorProvider.StaticMethod());
                 return builder.Build();
@@ -718,7 +720,7 @@ public sealed class WhereTest
     [TestMethod]
     public void StaticProperty()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Age] = @p1";
@@ -726,9 +728,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", AccessorProvider.StaticProperty);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Age == AccessorProvider.StaticProperty);
                 return builder.Build();
@@ -740,7 +742,7 @@ public sealed class WhereTest
     [TestMethod]
     public void Enum_AsVariable()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Sex] = @p1";
@@ -748,9 +750,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", Sex.Male);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 var sex = Sex.Male;  // as variable
                 builder.Where(x => x.Sex == sex);
@@ -763,7 +765,7 @@ public sealed class WhereTest
     [TestMethod]
     public void Enum_AsConstant()
     {
-        var actual = createQuery(this.Dialect);
+        var actual = createQuery();
         var expect =
 @"where
     [Sex] = @p1";
@@ -771,9 +773,9 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", (int)Sex.Female);
 
-        static Query createQuery(DbDialect dialect)
+        static Query createQuery()
         {
-            using (var builder = new QueryBuilder<Person>(dialect))
+            using (var builder = new QueryBuilder<Person>(s_dialect))
             {
                 builder.Where(static x => x.Sex == Sex.Female);
                 return builder.Build();

--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/WhereTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/WhereTest.cs
@@ -29,6 +29,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -37,6 +38,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -52,6 +54,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -60,6 +63,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -75,6 +79,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -83,6 +88,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -97,7 +103,8 @@ public sealed class WhereTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
-  
+
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -106,6 +113,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -120,6 +128,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -128,6 +137,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -142,6 +152,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -150,6 +161,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -163,6 +175,7 @@ public sealed class WhereTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -171,6 +184,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -184,6 +198,7 @@ public sealed class WhereTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -192,6 +207,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -207,6 +223,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -215,6 +232,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -230,6 +248,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p1", 1);
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -238,6 +257,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -254,6 +274,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -262,6 +283,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -278,6 +300,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -286,6 +309,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -302,6 +326,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -310,6 +335,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -326,6 +352,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -334,6 +361,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -356,6 +384,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p5");
         actual.Parameters!["p5"].ShouldBe(value2);
 
+        #region Local Functions
         static Query createQuery(int[] value1, int[] value2)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -365,6 +394,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -387,6 +417,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p5");
         actual.Parameters!["p5"].ShouldBe(value2);
 
+        #region Local Functions
         static Query createQuery(int[] value1, int[] value2)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -396,6 +427,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -412,6 +444,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -421,6 +454,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -437,6 +471,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKeyAndValue("p2", "xin9le");
         actual.Parameters.ShouldContainKeyAndValue("p3", 30);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -446,6 +481,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -462,6 +498,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p1");
         actual.Parameters!["p1"].ShouldBe(values);
 
+        #region Local Functions
         static Query createQuery(int[] values)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -470,6 +507,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -489,6 +527,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p2");
         actual.Parameters!["p2"].ShouldBe(value2);
 
+        #region Local Functions
         static Query createQuery(int[] value1, int[] value2)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -498,6 +537,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -511,6 +551,7 @@ public sealed class WhereTest
         actual.Text.ShouldBe(expect);
         actual.Parameters.ShouldBeNull();
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -520,6 +561,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -539,6 +581,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldContainKey("p2");
         actual.Parameters!["p2"].ShouldBe(value2);
 
+        #region Local Functions
         static Query createQuery(int[] value1, int[] value2)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -548,6 +591,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -563,6 +607,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", id);
 
+        #region Local Functions
         static Query createQuery(int id)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -571,6 +616,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -585,6 +631,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", "aaa");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -593,6 +640,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -615,6 +663,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", some.InstanceMethod());
 
+        #region Local Functions
         static Query createQuery(AccessorProvider some)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -623,6 +672,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -637,6 +687,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", "123");
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -646,6 +697,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -661,6 +713,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", some.InstanceProperty);
 
+        #region Local Functions
         static Query createQuery(AccessorProvider some)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -669,6 +722,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -684,6 +738,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", ids[0]);
 
+        #region Local Functions
         static Query createQuery(int[] ids)
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -692,6 +747,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -706,6 +762,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", AccessorProvider.StaticMethod());
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -714,6 +771,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -728,6 +786,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", AccessorProvider.StaticProperty);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -736,6 +795,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -750,6 +810,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", Sex.Male);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -759,6 +820,7 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 
 
@@ -773,6 +835,7 @@ public sealed class WhereTest
         actual.Parameters.ShouldNotBeNull();
         actual.Parameters.ShouldContainKeyAndValue("p1", (int)Sex.Female);
 
+        #region Local Functions
         static Query createQuery()
         {
             using (var builder = new QueryBuilder<Person>(s_dialect))
@@ -781,5 +844,6 @@ public sealed class WhereTest
                 return builder.Build();
             }
         }
+        #endregion
     }
 }


### PR DESCRIPTION
This pull request refactors the SQL Server unit tests to standardize the use of the database dialect and simplify test helper functions. The main changes involve replacing instance-level dialect fields with a static field, updating all usages to reference the static field, and removing unnecessary parameters from local helper functions. This results in more concise, maintainable, and consistent test code.