### PR TITLE
Implement IDisposable explicitly

### DIFF
--- a/src/libs/QLimitive/QueryBuilder.cs
+++ b/src/libs/QLimitive/QueryBuilder.cs
@@ -11,7 +11,7 @@ namespace QLimitive;
 /// Provides query builder.
 /// </summary>
 /// <typeparam name="T">Table mapping type</typeparam>
-public ref struct QueryBuilder<T> //: IDisposable
+public ref struct QueryBuilder<T> : IDisposable
 {
     #region Fields
     private readonly DbDialect _dialect;
@@ -35,7 +35,7 @@ public ref struct QueryBuilder<T> //: IDisposable
     #endregion
 
 
-    #region IDisposable implementations
+    #region IDisposable
     /// <summary>
     /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
     /// </summary>


### PR DESCRIPTION
This pull request makes minor improvements to the `QueryBuilder<T>` struct in the `QLimitive` namespace. The main change is to formally implement the `IDisposable` interface, ensuring proper resource management and clarity in the codebase.

- General improvements to resource management:
  * `QueryBuilder<T>` now explicitly implements the `IDisposable` interface, making its intent and usage clearer.
