### PR TITLE
Swap `.AsIs()` argument order

### DIFF
--- a/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
+++ b/src/insights/QLimitive.UnitTests/SqlServer/Cases/ComplexQueryTest.cs
@@ -209,8 +209,9 @@ order by
             {
                 builder.Select();
                 builder.Where(static x => x.Id == 1 || x.LastName != "xin9le" && x.Age > 20);
-                builder.AsIs(static (ref stringBuilder, ref bindParameters, dialect) =>
+                builder.AsIs(state: s_dialect, static (ref stringBuilder, ref bindParameters, state) =>
                 {
+                    var dialect = state;
                     var term = "csharp";
                     var table = TableMappingInfo.Get<Person>();
                     var bracket = dialect.KeywordBracket;
@@ -227,7 +228,7 @@ order by
 
                     bindParameters ??= [];
                     bindParameters.Add(nameof(term), term);
-                }, s_dialect);
+                });
                 builder.OrderBy(static x => x.Id);
                 builder.ThenByDescending(static x => x.Age);
                 return builder.Build();

--- a/src/libs/QLimitive/QueryBuilder.cs
+++ b/src/libs/QLimitive/QueryBuilder.cs
@@ -189,10 +189,10 @@ public ref struct QueryBuilder<T>(DbDialect dialect) : IDisposable
     /// Builds custom query by delegate-style.<br/>
     /// <b>This feature is provided for <i>as-is</i> use by those familiar with the internal implementation.</b>
     /// </summary>
-    /// <param name="action"></param>
     /// <param name="state"></param>
+    /// <param name="action"></param>
     /// <returns></returns>
-    public void AsIs<TState>(QueryBuildAction<TState> action, TState state)
+    public void AsIs<TState>(TState state, QueryBuildAction<TState> action)
     {
         var command = new AsIs<TState>(action, state);
         command.Build(ref this._stringHandler, ref this._bindParameters);


### PR DESCRIPTION
This pull request updates the usage and signature of the `AsIs` method in the query builder to improve its parameter order and consistency. The most important changes are:

**API changes and refactoring:**

* Changed the order of parameters in the generic `AsIs` method in `QueryBuilder` so that `state` comes before `action`, improving clarity and consistency. (`src/libs/QLimitive/QueryBuilder.cs`)
