### PR TITLE
Use `ImmutableArray<T>` instead of `ReadOnlyMemory<T>`

### DIFF
--- a/src/libs/QLimitive/Commands/Insert.cs
+++ b/src/libs/QLimitive/Commands/Insert.cs
@@ -24,7 +24,7 @@ internal readonly struct Insert<T>(DbDialect dialect, bool useAmbientValue)
     public void Build(ref DefaultInterpolatedStringHandler handler, ref BindParameterCollection? parameters)
     {
         var table = TableMappingInfo.Get<T>();
-        var columns = table.Columns.Span;
+        var columns = table.Columns.AsSpan();
         var bracket = this._dialect.KeywordBracket;
         var prefix = this._dialect.BindParameterPrefix;
 

--- a/src/libs/QLimitive/Commands/Select.cs
+++ b/src/libs/QLimitive/Commands/Select.cs
@@ -33,7 +33,7 @@ internal readonly struct Select<T>(DbDialect dialect, Expression<Func<T, object>
 
         //--- Build SQL
         var table = TableMappingInfo.Get<T>();
-        var columns = table.Columns.Span;
+        var columns = table.Columns.AsSpan();
         var bracket = this._dialect.KeywordBracket;
         handler.Append("select");
         foreach (var x in columns)

--- a/src/libs/QLimitive/Commands/Update.cs
+++ b/src/libs/QLimitive/Commands/Update.cs
@@ -34,7 +34,7 @@ internal readonly struct Update<T>(DbDialect dialect, Expression<Func<T, object>
 
         //--- Build SQL
         var table = TableMappingInfo.Get<T>();
-        var columns = table.Columns.Span;
+        var columns = table.Columns.AsSpan();
         var bracket = this._dialect.KeywordBracket;
         var prefix = this._dialect.BindParameterPrefix;
 

--- a/src/libs/QLimitive/Mappings/TableMappingInfo.cs
+++ b/src/libs/QLimitive/Mappings/TableMappingInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
@@ -38,7 +39,7 @@ public sealed class TableMappingInfo
     /// <summary>
     /// Gets the column mapping information.
     /// </summary>
-    public ReadOnlyMemory<ColumnMappingInfo> Columns { get; }
+    public ImmutableArray<ColumnMappingInfo> Columns { get; }
 
 
     /// <summary>
@@ -56,7 +57,7 @@ public sealed class TableMappingInfo
     /// <param name="type"></param>
     /// <param name="table"></param>
     /// <param name="columns"></param>
-    private TableMappingInfo(Type type, TableAttribute? table, ColumnMappingInfo[] columns)
+    private TableMappingInfo(Type type, TableAttribute? table, ImmutableArray<ColumnMappingInfo> columns)
     {
         this.Type = type;
         this.Schema = table?.Schema;
@@ -99,7 +100,7 @@ public sealed class TableMappingInfo
         {
             var type = typeof(T);
             var table = type.GetCustomAttributes<TableAttribute>(true).FirstOrDefault();
-            var columns = getColumns().ToArray();
+            var columns = getColumns().ToImmutableArray();
             Instance = new(type, table, columns);
 
             #region Local Functions


### PR DESCRIPTION
This pull request updates the way column mapping information is stored and accessed in the `TableMappingInfo` class and related command classes. The main change is migrating from using `ReadOnlyMemory<ColumnMappingInfo>` to `ImmutableArray<ColumnMappingInfo>` for storing columns, which improves immutability and safety.
