### PR TITLE
fix csproj path

### DIFF
--- a/nuget/pack.bat
+++ b/nuget/pack.bat
@@ -1,1 +1,1 @@
-dotnet pack ../src/QLimitive/QLimitive.csproj -c Release -o ./packages
+dotnet pack ../src/libs/QLimitive/QLimitive.csproj -c Release -o ./packages


### PR DESCRIPTION
This pull request updates the NuGet packaging script to point to the correct project directory for `QLimitive`.

- Updated the path in `nuget/pack.bat` to reference `../src/libs/QLimitive/QLimitive.csproj` instead of the previous location, ensuring the correct project is packaged.